### PR TITLE
Apply dominance rule in constant distributions

### DIFF
--- a/metasyncontrib/disclosure/base.py
+++ b/metasyncontrib/disclosure/base.py
@@ -1,6 +1,5 @@
 """Base class for all disclosure control distributions."""
 
-import polars as pl
 from metasyn.distribution.base import BaseDistribution
 
 
@@ -28,7 +27,6 @@ class DisclosureConstantMixin(BaseDistribution):
     @classmethod
     def fit(cls, series, *args, partition_size: int = 11, **kwargs) -> BaseDistribution:
         """Fit constant distributions with disclosure control rules in place."""
-
         # NB: dominance rule ensures that constant distribution is essentially never
         # allowed under formal disclosure control. Always return default distribution.
         return cls.default_distribution()

--- a/metasyncontrib/disclosure/base.py
+++ b/metasyncontrib/disclosure/base.py
@@ -30,6 +30,13 @@ class DisclosureConstantMixin(BaseDistribution):
         """Fit constant distributions with disclosure control rules in place."""
         pl_series: pl.Series = cls._to_series(series)
 
+        # NB: dominance rule ensures that constant distribution is essentially never
+        # allowed under formal disclosure control. Always return default distribution.
+        apply_dominance_rule: bool = True
+
+        if apply_dominance_rule:
+            return cls.default_distribution()
+
         # if unique, just get that value if it occurs at least n_avg times
         if pl_series.n_unique() == 1 and pl_series.len() >= n_avg:
             return cls._fit(pl_series, *args, **kwargs)
@@ -41,4 +48,3 @@ class DisclosureConstantMixin(BaseDistribution):
                 return cls._fit(pl_series, *args, **kwargs)
 
         return cls.default_distribution()
-

--- a/metasyncontrib/disclosure/base.py
+++ b/metasyncontrib/disclosure/base.py
@@ -28,7 +28,6 @@ class DisclosureConstantMixin(BaseDistribution):
     @classmethod
     def fit(cls, series, *args, partition_size: int = 11, **kwargs) -> BaseDistribution:
         """Fit constant distributions with disclosure control rules in place."""
-        pl_series: pl.Series = cls._to_series(series)
 
         # NB: dominance rule ensures that constant distribution is essentially never
         # allowed under formal disclosure control. Always return default distribution.

--- a/metasyncontrib/disclosure/categorical.py
+++ b/metasyncontrib/disclosure/categorical.py
@@ -24,7 +24,11 @@ class DisclosureMultinoulli(MultinoulliDistribution):
         probs = dist.probs[dist.probs >= n_avg / len(values)]
         if len(probs) == 0 or probs.max() >= 0.9:
             if MetaVar.get_var_type(values) == "discrete":
-                return cls([1, 2, 3], [0.1, 0.2, 0.7]) # type: ignore
+                return cls([77777, 88888, 99999], [0.1, 0.2, 0.7])  # type: ignore
             return cls.default_distribution()
         probs /= probs.sum()
         return cls(labels, probs)
+
+    @classmethod
+    def default_distribution(cls):  # noqa: D102
+        return cls(["A_REDACTED", "B_REDACTED", "C_REDACTED"], [0.1, 0.3, 0.6])

--- a/metasyncontrib/disclosure/continuous.py
+++ b/metasyncontrib/disclosure/continuous.py
@@ -43,5 +43,5 @@ class DisclosureConstant(DisclosureConstantMixin, ConstantDistribution):
     """Disclosure controlled ConstantDistribution."""
 
     @classmethod
-    def default_distribution(cls):
+    def default_distribution(cls):  # noqa: D102
         return cls(99999.9)

--- a/metasyncontrib/disclosure/continuous.py
+++ b/metasyncontrib/disclosure/continuous.py
@@ -37,6 +37,11 @@ class DisclosureTruncatedNormal(DisclosureNumericalMixin, TruncatedNormalDistrib
 class DisclosureExponential(DisclosureNumericalMixin, ExponentialDistribution):
     """Disclosure exponential distribution."""
 
+
 @metadist_disclosure()
 class DisclosureConstant(DisclosureConstantMixin, ConstantDistribution):
     """Disclosure controlled ConstantDistribution."""
+
+    @classmethod
+    def default_distribution(cls):
+        return cls(99999.9)

--- a/metasyncontrib/disclosure/datetime.py
+++ b/metasyncontrib/disclosure/datetime.py
@@ -60,16 +60,29 @@ class DisclosureDate(DateUniformDistribution):
         sub_series = pl.Series([dt_val.date() for dt_val in dt_sub_series])
         return cls(sub_series.min(), sub_series.max())
 
+
 @metadist_disclosure()
 class DisclosureDateTimeConstant(DisclosureConstantMixin, DateTimeConstantDistribution):
     """Disclosure controlled DateTimeConstantDistribution."""
+
+    @classmethod
+    def default_distribution(cls):
+        return cls("1970-01-01T00:00:00")
 
 
 @metadist_disclosure()
 class DisclosureTimeConstant(DisclosureConstantMixin, TimeConstantDistribution):
     """Disclosure controlled TimeConstantDistribution."""
 
+    @classmethod
+    def default_distribution(cls):
+        return cls("00:00:00")
+
 
 @metadist_disclosure()
 class DisclosureDateConstant(DisclosureConstantMixin, DateConstantDistribution):
     """Disclosure controlled DateConstantDistribution."""
+
+    @classmethod
+    def default_distribution(cls):
+        return cls("1970-01-01")

--- a/metasyncontrib/disclosure/datetime.py
+++ b/metasyncontrib/disclosure/datetime.py
@@ -66,7 +66,7 @@ class DisclosureDateTimeConstant(DisclosureConstantMixin, DateTimeConstantDistri
     """Disclosure controlled DateTimeConstantDistribution."""
 
     @classmethod
-    def default_distribution(cls):
+    def default_distribution(cls):  # noqa: D102
         return cls("1970-01-01T00:00:00")
 
 
@@ -75,7 +75,7 @@ class DisclosureTimeConstant(DisclosureConstantMixin, TimeConstantDistribution):
     """Disclosure controlled TimeConstantDistribution."""
 
     @classmethod
-    def default_distribution(cls):
+    def default_distribution(cls):  # noqa: D102
         return cls("00:00:00")
 
 
@@ -84,5 +84,5 @@ class DisclosureDateConstant(DisclosureConstantMixin, DateConstantDistribution):
     """Disclosure controlled DateConstantDistribution."""
 
     @classmethod
-    def default_distribution(cls):
+    def default_distribution(cls):  # noqa: D102
         return cls("1970-01-01")

--- a/metasyncontrib/disclosure/discrete.py
+++ b/metasyncontrib/disclosure/discrete.py
@@ -51,6 +51,11 @@ class DisclosureUniqueKey(UniqueKeyDistribution):
         sub_values = micro_aggregate(values, n_avg)
         return super()._fit(sub_values)
 
+
 @metadist_disclosure()
 class DisclosureDiscreteConstant(DisclosureConstantMixin, DiscreteConstantDistribution):
     """Disclosure controlled DiscreteConstantDistribution."""
+
+    @classmethod
+    def default_distribution(cls):
+        return cls(99999)

--- a/metasyncontrib/disclosure/discrete.py
+++ b/metasyncontrib/disclosure/discrete.py
@@ -57,5 +57,5 @@ class DisclosureDiscreteConstant(DisclosureConstantMixin, DiscreteConstantDistri
     """Disclosure controlled DiscreteConstantDistribution."""
 
     @classmethod
-    def default_distribution(cls):
+    def default_distribution(cls):  # noqa: D102
         return cls(99999)

--- a/metasyncontrib/disclosure/string.py
+++ b/metasyncontrib/disclosure/string.py
@@ -42,5 +42,5 @@ class DisclosureStringConstant(DisclosureConstantMixin, StringConstantDistributi
     """Disclosure controlled StringConstantDistribution."""
 
     @classmethod
-    def default_distribution(cls):
+    def default_distribution(cls):  # noqa: D102
         return cls("REDACTED")

--- a/metasyncontrib/disclosure/string.py
+++ b/metasyncontrib/disclosure/string.py
@@ -36,6 +36,11 @@ class DisclosureFreetext(FreeTextDistribution):
     def _fit(cls, values, max_values: int = 50, n_avg: int = 11):  # pylint: disable=unused-argument
         return super()._fit(values, max_values=max_values)
 
+
 @metadist_disclosure()
 class DisclosureStringConstant(DisclosureConstantMixin, StringConstantDistribution):
     """Disclosure controlled StringConstantDistribution."""
+
+    @classmethod
+    def default_distribution(cls):
+        return cls("REDACTED")

--- a/tests/test_constant.py
+++ b/tests/test_constant.py
@@ -19,19 +19,18 @@ from metasyncontrib.disclosure.string import DisclosureStringConstant
 
 
 @mark.parametrize(
-    "dist_builtin, dist_disclosure, value",
+    "dist_builtin, dist_disclosure, value, disclosurevalue",
     [
-        (ConstantDistribution, DisclosureConstant, 8.0),
-        (DiscreteConstantDistribution, DisclosureDiscreteConstant, 8),
-        (StringConstantDistribution, DisclosureStringConstant, "Secretvalue"),
-        (DateTimeConstantDistribution, DisclosureDateTimeConstant, "2024-02-23T12:08:38"),
-        (TimeConstantDistribution, DisclosureTimeConstant, "12:08:38"),
-        (DateConstantDistribution, DisclosureDateConstant, "2024-02-23"),
+        (ConstantDistribution, DisclosureConstant, 8.0, 99999.9),
+        (DiscreteConstantDistribution, DisclosureDiscreteConstant, 8, 99999),
+        (StringConstantDistribution, DisclosureStringConstant, "Secretvalue", "REDACTED"),
+        (DateTimeConstantDistribution, DisclosureDateTimeConstant, "2024-02-23T12:08:38", "1970-01-01T00:00:00"),  # noqa: E501
+        (TimeConstantDistribution, DisclosureTimeConstant, "12:08:38", "00:00:00"),
+        (DateConstantDistribution, DisclosureDateConstant, "2024-02-23", "1970-01-01"),
     ],
 )
-def test_constant(dist_builtin, dist_disclosure, value):
+def test_constant(dist_builtin, dist_disclosure, value, disclosurevalue):  # noqa: D103
     dist = dist_builtin(value)
     data = [dist.draw() for _ in range(21)]
 
-    assert dist_disclosure.fit(data, n_avg=22)._param_dict().get("value") != value
-    assert dist_disclosure.fit(data, n_avg=11)._param_dict().get("value") == value
+    assert dist_disclosure.fit(data, n_avg=11)._param_dict().get("value") == disclosurevalue


### PR DESCRIPTION
fixes #36

Here's a test script:

```py
from metasyn import MetaFrame, VarSpec
from metasyncontrib.disclosure import DisclosurePrivacy
import polars as pl

df = (
    pl.DataFrame({"id": range(30)})
    .with_columns(
        pl.lit(1.0).alias("TESTCONT"),
        pl.lit(8).alias("TESTDISC"),
        pl.lit("Secret string").alias("TESTSTR"),
        pl.lit("2021-02-03").str.to_date().alias("TESTDATE"),
        pl.lit("12:35:01").str.to_time().alias("TESTTIME"),
        pl.lit("2021-02-03T12:35:01").str.to_datetime().alias("TESTDATETIME"),
    )
)

mf = MetaFrame.fit_dataframe(df, privacy=DisclosurePrivacy(), var_specs=[VarSpec("id", unique=True)])

# original data
df

# synthetic data
mf.synthesize(30)
```

## Original data
```
┌─────┬──────────┬──────────┬───────────────┬────────────┬──────────┬─────────────────────┐
│ id  ┆ TESTCONT ┆ TESTDISC ┆ TESTSTR       ┆ TESTDATE   ┆ TESTTIME ┆ TESTDATETIME        │
│ --- ┆ ---      ┆ ---      ┆ ---           ┆ ---        ┆ ---      ┆ ---                 │
│ i64 ┆ f64      ┆ i32      ┆ str           ┆ date       ┆ time     ┆ datetime[μs]        │
╞═════╪══════════╪══════════╪═══════════════╪════════════╪══════════╪═════════════════════╡
│ 0   ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 1   ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 2   ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 3   ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 4   ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ …   ┆ …        ┆ …        ┆ …             ┆ …          ┆ …        ┆ …                   │
│ 25  ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 26  ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 27  ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 28  ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
│ 29  ┆ 1.0      ┆ 8        ┆ Secret string ┆ 2021-02-03 ┆ 12:35:01 ┆ 2021-02-03 12:35:01 │
└─────┴──────────┴──────────┴───────────────┴────────────┴──────────┴─────────────────────┘
```

## Synthetic
```
┌─────┬──────────┬──────────┬──────────┬────────────┬──────────┬─────────────────────┐
│ id  ┆ TESTCONT ┆ TESTDISC ┆ TESTSTR  ┆ TESTDATE   ┆ TESTTIME ┆ TESTDATETIME        │
│ --- ┆ ---      ┆ ---      ┆ ---      ┆ ---        ┆ ---      ┆ ---                 │
│ i64 ┆ f64      ┆ i64      ┆ str      ┆ date       ┆ time     ┆ datetime[μs]        │
╞═════╪══════════╪══════════╪══════════╪════════════╪══════════╪═════════════════════╡
│ 0   ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 1   ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 2   ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 3   ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 4   ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ …   ┆ …        ┆ …        ┆ …        ┆ …          ┆ …        ┆ …                   │
│ 25  ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 26  ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 27  ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 28  ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
│ 29  ┆ 99999.9  ┆ 99999    ┆ REDACTED ┆ 1970-01-01 ┆ 00:00:00 ┆ 1970-01-01 00:00:00 │
└─────┴──────────┴──────────┴──────────┴────────────┴──────────┴─────────────────────┘