### PR TITLE
Make the DisclosureFreetext fitter more private

### DIFF
--- a/metasyncontrib/disclosure/freetext.py
+++ b/metasyncontrib/disclosure/freetext.py
@@ -11,3 +11,6 @@ class DisclosureFreetext(FreeTextFitter):
 
     This implementation is the same as the original.
     """
+
+    def _fit(self, series, max_values: int = 50):
+        return self.distribution.default_distribution()


### PR DESCRIPTION
Only return the default distribution, since controling privacy will be hard otherwise to implement. Fixes #47